### PR TITLE
Issue 20: auto detect whether stream includes SchemaRegistry encoding info

### DIFF
--- a/.github/workflows/pravega-build.yml
+++ b/.github/workflows/pravega-build.yml
@@ -29,6 +29,8 @@ jobs:
         uses: actions/setup-java@v1
         with:
           java-version: 11
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
       - name: Build Output Cache
         uses: actions/cache@v2.1.0
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -25,4 +25,5 @@ benchmark_outputs
 .checkstyle
 .editorconfig
 node_modules
-
+schema_registry.log
+schema_registry.*gz

--- a/.gitignore
+++ b/.gitignore
@@ -25,5 +25,5 @@ benchmark_outputs
 .checkstyle
 .editorconfig
 node_modules
-schema_registry.log
-schema_registry.*gz
+schema-registry.log
+schema_registry_*.gz

--- a/build.gradle
+++ b/build.gradle
@@ -67,6 +67,7 @@ dependencies {
     testImplementation "com.facebook.airlift:testing:${airliftTestingVersion}"
 
     testCompile (group: 'io.pravega', name: 'pravega-standalone', version: pravegaVersion)
+    testCompile "io.pravega:schemaregistry-server:${pravegaSchemaRegistryVersion}"
 
     compileOnly "io.airlift:slice:${airliftSliceVersion}"
     compileOnly "io.airlift:units:${airliftUnitsVersion}"

--- a/build.gradle
+++ b/build.gradle
@@ -6,9 +6,18 @@ plugins {
     id 'java'
     id 'distribution'
     id 'maven'
+    id 'com.commercehub.gradle.plugin.avro' version "0.99.99"
+    id 'com.google.protobuf' version "0.8.16"
 }
 
+apply plugin: 'java'
 apply from: "$rootDir/gradle/checkstyle.gradle"
+
+apply plugin: 'com.google.protobuf'
+sourceSets.main.java.srcDirs += 'build/generated/source/proto/test/java/'
+
+apply plugin: "com.commercehub.gradle.plugin.avro"
+sourceSets.main.java.srcDirs += 'build/generated-test-avro-java/'
 
 repositories {
     mavenLocal()

--- a/src/main/java/io/pravega/connectors/presto/PravegaRecordSetProvider.java
+++ b/src/main/java/io/pravega/connectors/presto/PravegaRecordSetProvider.java
@@ -47,12 +47,9 @@ import java.util.Set;
 
 import static io.pravega.connectors.presto.PravegaHandleResolver.convertSplit;
 import static io.pravega.connectors.presto.util.PravegaSchemaUtils.AVRO;
-import static io.pravega.connectors.presto.util.PravegaSchemaUtils.AVRO_INLINE;
 import static io.pravega.connectors.presto.util.PravegaSchemaUtils.CSV;
 import static io.pravega.connectors.presto.util.PravegaSchemaUtils.JSON;
-import static io.pravega.connectors.presto.util.PravegaSchemaUtils.JSON_INLINE;
 import static io.pravega.connectors.presto.util.PravegaSchemaUtils.PROTOBUF;
-import static io.pravega.connectors.presto.util.PravegaSchemaUtils.PROTOBUF_INLINE;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.Objects.requireNonNull;
 
@@ -166,18 +163,12 @@ public class PravegaRecordSetProvider
     {
         switch (schema.getFormat()) {
             case AVRO:
-                return new AvroSerializer(schema.getSchemaLocation().get());
-            case AVRO_INLINE:
-                return new AvroSerializer(serializerConfig);
+                return new AvroSerializer(serializerConfig, schema.getSchemaLocation().get());
 
             case PROTOBUF:
-                return new ProtobufSerializer(schema.getSchemaLocation().get());
-            case PROTOBUF_INLINE:
-                return new ProtobufSerializer(serializerConfig);
+                return new ProtobufSerializer(serializerConfig, schema.getSchemaLocation().get());
 
             case JSON:
-                return new JsonSerializer();
-            case JSON_INLINE:
                 return new JsonSerializer(serializerConfig);
 
             case CSV:
@@ -192,15 +183,12 @@ public class PravegaRecordSetProvider
     {
         switch (schema.getFormat()) {
             case AVRO:
-            case AVRO_INLINE:
                 return new AvroRowDecoder(decoderColumnHandles);
 
             case PROTOBUF:
-            case PROTOBUF_INLINE:
                 return new ProtobufRowDecoder(decoderColumnHandles);
 
             case JSON:
-            case JSON_INLINE:
                 return jsonRowDecoderFactory.create(decoderColumnHandles);
 
             case CSV: {

--- a/src/main/java/io/pravega/connectors/presto/decoder/AvroSerializer.java
+++ b/src/main/java/io/pravega/connectors/presto/decoder/AvroSerializer.java
@@ -16,10 +16,9 @@
 
 package io.pravega.connectors.presto.decoder;
 
-import com.facebook.airlift.log.Logger;
 import io.pravega.connectors.presto.util.ByteBufferInputStream;
-import com.google.protobuf.DynamicMessage;
 import io.pravega.client.stream.Serializer;
+import io.pravega.connectors.presto.util.PravegaSerializationUtils;
 import io.pravega.schemaregistry.serializer.shared.impl.SerializerConfig;
 import org.apache.avro.Schema;
 import org.apache.avro.file.DataFileStream;
@@ -34,7 +33,6 @@ import java.nio.ByteBuffer;
 // deserialize using externally provided schema or using SR+SerializerConfig
 public class AvroSerializer
         extends KVSerializer<GenericRecord> {
-    private static final Logger log = Logger.get(AvroSerializer.class);
 
     private static class GenericRecordSerializer
             implements Serializer<Object> {
@@ -48,8 +46,9 @@ public class AvroSerializer
         }
 
         @Override
-        public ByteBuffer serialize(Object value) {
-            return ByteBuffer.wrap(((DynamicMessage) value).toByteArray());
+        public ByteBuffer serialize(Object object)
+        {
+            return PravegaSerializationUtils.serialize((GenericRecord) object);
         }
 
         @Override

--- a/src/main/java/io/pravega/connectors/presto/decoder/AvroSerializer.java
+++ b/src/main/java/io/pravega/connectors/presto/decoder/AvroSerializer.java
@@ -16,11 +16,11 @@
 
 package io.pravega.connectors.presto.decoder;
 
+import com.facebook.airlift.log.Logger;
 import io.pravega.connectors.presto.util.ByteBufferInputStream;
 import com.google.protobuf.DynamicMessage;
 import io.pravega.client.stream.Serializer;
 import io.pravega.schemaregistry.serializer.shared.impl.SerializerConfig;
-import io.pravega.schemaregistry.serializers.SerializerFactory;
 import org.apache.avro.Schema;
 import org.apache.avro.file.DataFileStream;
 import org.apache.avro.generic.GenericDatumReader;
@@ -33,32 +33,29 @@ import java.nio.ByteBuffer;
 
 // deserialize using externally provided schema or using SR+SerializerConfig
 public class AvroSerializer
-        extends KVSerializer<GenericRecord>
-{
+        extends KVSerializer<GenericRecord> {
+    private static final Logger log = Logger.get(AvroSerializer.class);
+
     private static class GenericRecordSerializer
-            implements Serializer<Object>
-    {
+            implements Serializer<Object> {
         private final DatumReader<GenericRecord> datumReader;
 
         private final Schema schema;
 
-        GenericRecordSerializer(Schema schema)
-        {
+        GenericRecordSerializer(Schema schema) {
             this.datumReader = new GenericDatumReader(schema);
             this.schema = schema;
         }
 
         @Override
-        public ByteBuffer serialize(Object value)
-        {
+        public ByteBuffer serialize(Object value) {
             return ByteBuffer.wrap(((DynamicMessage) value).toByteArray());
         }
 
         @Override
-        public GenericRecord deserialize(ByteBuffer serializedValue)
-        {
+        public GenericRecord deserialize(ByteBuffer serializedValue) {
             try (DataFileStream<GenericRecord> dataFileReader =
-                    new DataFileStream<>(new ByteBufferInputStream(serializedValue), datumReader)) {
+                         new DataFileStream<>(new ByteBufferInputStream(serializedValue), datumReader)) {
                 // TODO: need to figure out how to auto-detect format of avro data
                 // for e.g, is schema provided for every row? (this is how the normal presto avro decoder takes it)
                 // i would think more typically case would be that schema defined once and thus schema not provided
@@ -66,24 +63,20 @@ public class AvroSerializer
                 //
                 // for now we will do it the "presto way"
                 return dataFileReader.next();
-            }
-            catch (IOException e) {
+            } catch (IOException e) {
                 throw new UncheckedIOException(e);
             }
         }
     }
 
-    private final Serializer<Object> delegate;
-
-    public AvroSerializer(SerializerConfig config)
-    {
-        this.delegate = SerializerFactory.genericDeserializer(config);
+    public AvroSerializer(SerializerConfig config, String schema) {
+        super(config, schema);
     }
 
-    public AvroSerializer(String encodedSchema)
+    @Override
+    public Serializer<Object> serializerForSchema(String schema)
     {
-        Schema schema = (new Schema.Parser()).parse(encodedSchema);
-        this.delegate = new GenericRecordSerializer(schema);
+        return new GenericRecordSerializer((new Schema.Parser()).parse(schema));
     }
 
     @Override
@@ -95,7 +88,7 @@ public class AvroSerializer
     @Override
     public GenericRecord deserialize(ByteBuffer serializedValue)
     {
-        return (GenericRecord) delegate.deserialize(serializedValue);
+        return super.deserialize(serializedValue);
     }
 
     @Override

--- a/src/main/java/io/pravega/connectors/presto/decoder/CsvSerializer.java
+++ b/src/main/java/io/pravega/connectors/presto/decoder/CsvSerializer.java
@@ -15,6 +15,8 @@
  */
 
 package io.pravega.connectors.presto.decoder;
+import io.pravega.client.stream.Serializer;
+
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 
@@ -23,6 +25,7 @@ public class CsvSerializer
 {
     public CsvSerializer()
     {
+        super(null, null);
     }
 
     @Override
@@ -37,6 +40,12 @@ public class CsvSerializer
         return new String(serializedValue.array(),
                 serializedValue.arrayOffset() + serializedValue.position(),
                 serializedValue.remaining());
+    }
+
+    @Override
+    public Serializer<Object> serializerForSchema(String schema)
+    {
+        throw new UnsupportedOperationException();
     }
 
     @Override

--- a/src/main/java/io/pravega/connectors/presto/decoder/JsonSerializer.java
+++ b/src/main/java/io/pravega/connectors/presto/decoder/JsonSerializer.java
@@ -59,16 +59,15 @@ public class JsonSerializer
         }
     }
 
-    private final Serializer<Object> delegate;
-
     public JsonSerializer(SerializerConfig config)
     {
-        this.delegate = SerializerFactory.genericDeserializer(config);
+        super(config, null);
     }
 
-    public JsonSerializer()
+    @Override
+    public Serializer<Object> serializerForSchema(String schema /* null for json */)
     {
-        this.delegate = new JsonTreeSerializer();
+        return new JsonTreeSerializer();
     }
 
     @Override
@@ -80,7 +79,7 @@ public class JsonSerializer
     @Override
     public JsonNode deserialize(ByteBuffer serializedValue)
     {
-        return (JsonNode) delegate.deserialize(serializedValue);
+        return super.deserialize(serializedValue);
     }
 
     @Override

--- a/src/main/java/io/pravega/connectors/presto/decoder/KVSerializer.java
+++ b/src/main/java/io/pravega/connectors/presto/decoder/KVSerializer.java
@@ -16,12 +16,67 @@
 
 package io.pravega.connectors.presto.decoder;
 
+import com.facebook.airlift.log.Logger;
 import io.pravega.client.stream.Serializer;
+import io.pravega.schemaregistry.serializer.shared.impl.SerializerConfig;
+import io.pravega.schemaregistry.serializers.SerializerFactory;
+
+import java.nio.ByteBuffer;
 
 // deserialize using externally provided schema or using SR+SerializerConfig
 public abstract class KVSerializer<T>
-        implements Serializer<T>
-{
+        implements Serializer<T> {
+    private static final Logger log = Logger.get(KVSerializer.class);
+
+    protected Serializer<Object> delegate = null;
+
+    private boolean schemaRegistryDeserializer;
+
+    private final SerializerConfig serializerConfig;
+
+    private final String schema;
+
+    protected KVSerializer(SerializerConfig serializerConfig, String schema) {
+        this.serializerConfig = serializerConfig;
+        this.schema = schema;
+    }
+
+    public boolean schemaRegistryDeserializer()
+    {
+        return schemaRegistryDeserializer;
+    }
+
+    // format of data is unknown, whether schema is encoded inline by pravega schema registry or not
+    // try to deserialize without, and if it fails, use serializerConfig
+    protected void chooseDeserializer(ByteBuffer serializedValue)
+    {
+        Serializer<Object> serializer = serializerForSchema(schema);
+        serializedValue.mark();
+        try {
+            if (serializer.deserialize(serializedValue) != null) {
+                delegate = serializer;
+            }
+        }
+        catch (RuntimeException e) {
+            log.info("could not deserialize, try SR deserializer");
+            delegate = SerializerFactory.genericDeserializer(serializerConfig);
+            schemaRegistryDeserializer = true;
+        }
+        finally {
+            serializedValue.reset();
+        }
+    }
+
+    public T deserialize(ByteBuffer serializedValue)
+    {
+        if (delegate == null) {
+            chooseDeserializer(serializedValue);
+        }
+        return (T) delegate.deserialize(serializedValue);
+    }
+
+    public abstract Serializer<Object> serializerForSchema(String schema);
+
     // create an event that can be passed down to decoders
     public abstract DecodableEvent toEvent(Object obj);
 }

--- a/src/main/java/io/pravega/connectors/presto/util/PravegaSchemaUtils.java
+++ b/src/main/java/io/pravega/connectors/presto/util/PravegaSchemaUtils.java
@@ -40,13 +40,6 @@ public class PravegaSchemaUtils
 
     private static final Logger log = Logger.get(PravegaSchemaUtils.class);
 
-    public static final String AVRO_INLINE = "avro-inline";
-    public static final String PROTOBUF_INLINE = "protobuf-inline";
-    public static final String JSON_INLINE = "json-inline";
-    public static final String INLINE_SUFFIX = "-inline";
-    public static final String GROUP_PROPERTIES_INLINE_KEY = "inline";
-    public static final String GROUP_PROPERTIES_INLINE_KV_KEY = "inlinekey";
-    public static final String GROUP_PROPERTIES_INLINE_KV_VALUE = "inlinevalue";
     public static final String AVRO = "avro";
     public static final String PROTOBUF = "protobuf";
     public static final String JSON = "json";

--- a/src/main/java/io/pravega/connectors/presto/util/PravegaSerializationUtils.java
+++ b/src/main/java/io/pravega/connectors/presto/util/PravegaSerializationUtils.java
@@ -16,6 +16,10 @@
 
 package io.pravega.connectors.presto.util;
 
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -23,6 +27,7 @@ import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
 import java.io.UncheckedIOException;
+import java.nio.ByteBuffer;
 
 public class PravegaSerializationUtils
 {
@@ -55,6 +60,23 @@ public class PravegaSerializationUtils
         }
         catch (ClassNotFoundException e) {
             throw new IllegalArgumentException(e);
+        }
+    }
+
+    public static ByteBuffer serialize(GenericRecord record)
+    {
+        try {
+            GenericDatumWriter<GenericRecord> writer = new GenericDatumWriter<>(record.getSchema());
+            DataFileWriter<GenericRecord> dataFileWriter = new DataFileWriter<>(writer);
+
+            ByteArrayOutputStream os = new ByteArrayOutputStream();
+            dataFileWriter.create(record.getSchema(), os);
+            dataFileWriter.append(record);
+            dataFileWriter.close();
+            return ByteBuffer.wrap(os.toByteArray());
+        }
+        catch (IOException e) {
+            throw new UncheckedIOException(e);
         }
     }
 }

--- a/src/test/avro/sensor.avsc
+++ b/src/test/avro/sensor.avsc
@@ -1,0 +1,10 @@
+{
+    "namespace": "io.pravega.avro",
+    "type": "record",
+    "name": "Sensor",
+    "fields": [
+        {"name": "sensorId", "type": "int"},
+        {"name": "timestamp", "type": "long"},
+        {"name": "rate", "type": "double"}
+    ]
+}

--- a/src/test/java/io/pravega/connectors/presto/decoder/KVSerializerTest.java
+++ b/src/test/java/io/pravega/connectors/presto/decoder/KVSerializerTest.java
@@ -19,26 +19,50 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.protobuf.Descriptors;
+import com.google.protobuf.DynamicMessage;
+import io.pravega.avro.Sensor;
 import io.pravega.client.stream.Serializer;
 import io.pravega.connectors.presto.integration.EmbeddedSchemaRegistry;
+import io.pravega.connectors.presto.util.PravegaSerializationUtils;
+import io.pravega.protobuf.ProductOuterClass;
 import io.pravega.schemaregistry.client.SchemaRegistryClientConfig;
+import io.pravega.schemaregistry.client.exceptions.RegistryExceptions;
 import io.pravega.schemaregistry.contract.data.Compatibility;
 import io.pravega.schemaregistry.contract.data.GroupProperties;
 import io.pravega.schemaregistry.contract.data.SerializationFormat;
+import io.pravega.schemaregistry.serializer.avro.schemas.AvroSchema;
 import io.pravega.schemaregistry.serializer.json.schemas.JSONSchema;
+import io.pravega.schemaregistry.serializer.protobuf.schemas.ProtobufSchema;
 import io.pravega.schemaregistry.serializer.shared.impl.SerializerConfig;
 import io.pravega.schemaregistry.serializers.SerializerFactory;
+import org.apache.avro.generic.GenericRecord;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.Map;
+import java.util.Random;
+import java.util.UUID;
 
+import static io.pravega.connectors.presto.ProtobufCommon.encodeSchema;
 import static org.testng.Assert.*;
 
+/**
+ * when an object is written to pravega using serializer from SchemaRegistry, encoding info
+ * will be added to the raw event data so the event can be deserialized automatically later
+ * this is referred to in the connector code as "inline"
+ *
+ * when reading data in the connector, we don't know how event was serialized
+ * so first try with the actual avro, protobuf, or json schema
+ * if that fails fallback to trying with SchemaRegistry SerializerConfig
+ */
 @Test
 public class KVSerializerTest {
     private final EmbeddedSchemaRegistry schemaRegistry;
+
+    private final Random random = new Random();
 
     public KVSerializerTest() {
         this.schemaRegistry = new EmbeddedSchemaRegistry();
@@ -76,12 +100,13 @@ public class KVSerializerTest {
     }
 
     @Test
-    public void testJson() throws IOException
-    {
+    public void testJson() throws IOException {
         Employee expected = new Employee(1, "John", "Smith");
+
         ByteBuffer serialized = ByteBuffer.wrap(new ObjectMapper().writeValueAsBytes(expected));
 
-        JsonSerializer jsonSerializer = new JsonSerializer(null /* no need to pass config - won't fall back */);
+        // use null SerializerConfig as we are not expecting initial deserialize to fail
+        JsonSerializer jsonSerializer = new JsonSerializer(null);
 
         JsonNode actual = jsonSerializer.deserialize(serialized);
 
@@ -93,18 +118,19 @@ public class KVSerializerTest {
     }
 
     @Test
-    public void testJsonInline() {
-        SerializerConfig serializerConfig = jsonGroup("inline");
-
-        Serializer<Employee> serializer =
-                SerializerFactory.jsonSerializer(serializerConfig, JSONSchema.of(Employee.class));
-
+    public void testJsonInline()
+    {
         Employee expected = new Employee(1, "John", "Smith");
-        ByteBuffer serialized = serializer.serialize(expected);
+
+        SerializerConfig serializerConfig = jsonGroup("inline");
+        Serializer<Employee> schemaRegistrySerializer =
+                SerializerFactory.jsonSerializer(serializerConfig, JSONSchema.of(Employee.class));
+        // using Serializer provided by SchemaRegistry
+        ByteBuffer serializedValue = schemaRegistrySerializer.serialize(expected);
 
         JsonSerializer jsonSerializer = new JsonSerializer(serializerConfig);
 
-        JsonNode actual = jsonSerializer.deserialize(serialized);
+        JsonNode actual = jsonSerializer.deserialize(serializedValue);
 
         assertEquals(actual.get("id").asInt(), expected.id);
         assertEquals(actual.get("first").asText(), expected.first);
@@ -113,7 +139,106 @@ public class KVSerializerTest {
         assertTrue(jsonSerializer.schemaRegistryDeserializer());
     }
 
-    private SerializerConfig jsonGroup(String stream) {
+    @Test
+    public void testAvro()
+    {
+        Sensor sensor = new Sensor();
+        sensor.setSensorId(random.nextInt());
+        sensor.setTimestamp(System.currentTimeMillis());
+        sensor.setRate(random.nextDouble());
+
+        ByteBuffer serializedValue = PravegaSerializationUtils.serialize((GenericRecord) sensor);
+
+        // use null SerializerConfig as we are expecting parse with given schema to succeed
+        AvroSerializer avroSerializer = new AvroSerializer(null, sensor.getSchema().toString());
+        GenericRecord actual = avroSerializer.deserialize(serializedValue);
+
+        assertEquals(actual.get("sensorId"), sensor.getSensorId());
+        assertEquals(actual.get("timestamp"), sensor.getTimestamp());
+        assertEquals(actual.get("rate"), sensor.getRate());
+
+        assertFalse(avroSerializer.schemaRegistryDeserializer());
+    }
+
+    @Test
+    public void testAvroInline()
+    {
+        Sensor sensor = new Sensor();
+        sensor.setSensorId(random.nextInt());
+        sensor.setTimestamp(System.currentTimeMillis());
+        sensor.setRate(random.nextDouble());
+
+        SerializerConfig serializerConfig = avroGroup("inline");
+        Serializer<Sensor> schemaRegistrySerializer =
+                SerializerFactory.avroSerializer(serializerConfig, AvroSchema.of(Sensor.class));
+        // using Serializer provided by SchemaRegistry
+        ByteBuffer serializedValue = schemaRegistrySerializer.serialize(sensor);
+
+        AvroSerializer avroSerializer = new AvroSerializer(serializerConfig, sensor.getSchema().toString());
+        GenericRecord actual = avroSerializer.deserialize(serializedValue);
+
+        assertEquals(actual.get("sensorId"), sensor.getSensorId());
+        assertEquals(actual.get("timestamp"), sensor.getTimestamp());
+        assertEquals(actual.get("rate"), sensor.getRate());
+
+        assertTrue(avroSerializer.schemaRegistryDeserializer());
+    }
+
+    @Test
+    public void testProtobufInline()
+    {
+        ProductOuterClass.Product product = ProductOuterClass.Product.newBuilder()
+                .setId(random.nextInt())
+                .setName(UUID.randomUUID().toString())
+                .build();
+
+        SerializerConfig serializerConfig = protobufGroup("inline");
+        Serializer<ProductOuterClass.Product> schemaRegistrySerializer =
+                SerializerFactory.protobufSerializer(serializerConfig, ProtobufSchema.of(ProductOuterClass.Product.class));
+        // using Serializer provided by SchemaRegistry
+        ByteBuffer serializedValue = schemaRegistrySerializer.serialize(product);
+
+        // get file descriptor, which is needed for initial DynamicMessage#parseFrom
+        String schema = encodeSchema(schemaRegistry.client().getSchemas("protobuf.inline").get(0));
+
+        ProtobufSerializer protobufSerializer = new ProtobufSerializer(serializerConfig, schema);
+        DynamicMessage dynamicMessage = protobufSerializer.deserialize(serializedValue);
+
+        int id = -1;
+        String name = null;
+        for (Map.Entry<Descriptors.FieldDescriptor, Object> entry : dynamicMessage.getAllFields().entrySet()) {
+            if (entry.getKey().getJsonName().equals("id")) {
+                id = (int) entry.getValue();
+            }
+            else if (entry.getKey().getJsonName().equals("name")) {
+                name = (String) entry.getValue();
+            }
+        }
+        assertNotEquals(id, -1);
+        assertNotNull(name);
+
+        assertEquals(id, product.getId());
+        assertEquals(name, product.getName());
+
+        assertTrue(protobufSerializer.schemaRegistryDeserializer());
+    }
+
+    private SerializerConfig avroGroup(String stream)
+    {
+        String groupId = "avro." + stream;
+        addGroup(groupId, SerializationFormat.Avro);
+        return serializerConfig(groupId);
+    }
+
+    private SerializerConfig protobufGroup(String stream)
+    {
+        String groupId = "protobuf." + stream;
+        addGroup(groupId, SerializationFormat.Protobuf);
+        return serializerConfig(groupId);
+    }
+
+    private SerializerConfig jsonGroup(String stream)
+    {
         String groupId = "json." + stream;
         addGroup(groupId, SerializationFormat.Json);
         return serializerConfig(groupId);
@@ -121,11 +246,16 @@ public class KVSerializerTest {
 
     private void addGroup(String groupId, SerializationFormat format)
     {
-        schemaRegistry.client().addGroup(groupId,
-                new GroupProperties(
-                        format,
-                        Compatibility.allowAny(),
-                        true));
+        try {
+            schemaRegistry.client().getGroupProperties(groupId);
+        }
+        catch (RegistryExceptions.ResourceNotFoundException e) {
+            schemaRegistry.client().addGroup(groupId,
+                    new GroupProperties(
+                            format,
+                            Compatibility.allowAny(),
+                            true));
+        }
     }
 
     private SerializerConfig serializerConfig(String group) {

--- a/src/test/java/io/pravega/connectors/presto/decoder/KVSerializerTest.java
+++ b/src/test/java/io/pravega/connectors/presto/decoder/KVSerializerTest.java
@@ -1,0 +1,145 @@
+/*
+ * Copyright (c) Pravega Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.pravega.connectors.presto.decoder;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.pravega.client.stream.Serializer;
+import io.pravega.connectors.presto.integration.EmbeddedSchemaRegistry;
+import io.pravega.schemaregistry.client.SchemaRegistryClientConfig;
+import io.pravega.schemaregistry.contract.data.Compatibility;
+import io.pravega.schemaregistry.contract.data.GroupProperties;
+import io.pravega.schemaregistry.contract.data.SerializationFormat;
+import io.pravega.schemaregistry.serializer.json.schemas.JSONSchema;
+import io.pravega.schemaregistry.serializer.shared.impl.SerializerConfig;
+import io.pravega.schemaregistry.serializers.SerializerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+
+import static org.testng.Assert.*;
+
+@Test
+public class KVSerializerTest {
+    private final EmbeddedSchemaRegistry schemaRegistry;
+
+    public KVSerializerTest() {
+        this.schemaRegistry = new EmbeddedSchemaRegistry();
+        this.schemaRegistry.start();
+    }
+
+    private static class Employee {
+        public int id;
+        public String first;
+        public String last;
+
+        @JsonCreator
+        public Employee(@JsonProperty("id") int id,
+                        @JsonProperty("first") String first,
+                        @JsonProperty("last") String last) {
+            this.id = id;
+            this.first = first;
+            this.last = last;
+        }
+
+        @JsonProperty
+        public int getId() {
+            return id;
+        }
+
+        @JsonProperty
+        public String getFirst() {
+            return first;
+        }
+
+        @JsonProperty
+        public String getLast() {
+            return last;
+        }
+    }
+
+    @Test
+    public void testJson() throws IOException
+    {
+        Employee expected = new Employee(1, "John", "Smith");
+        ByteBuffer serialized = ByteBuffer.wrap(new ObjectMapper().writeValueAsBytes(expected));
+
+        JsonSerializer jsonSerializer = new JsonSerializer(null /* no need to pass config - won't fall back */);
+
+        JsonNode actual = jsonSerializer.deserialize(serialized);
+
+        assertEquals(actual.get("id").asInt(), expected.id);
+        assertEquals(actual.get("first").asText(), expected.first);
+        assertEquals(actual.get("last").asText(), expected.last);
+
+        assertFalse(jsonSerializer.schemaRegistryDeserializer());
+    }
+
+    @Test
+    public void testJsonInline() {
+        SerializerConfig serializerConfig = jsonGroup("inline");
+
+        Serializer<Employee> serializer =
+                SerializerFactory.jsonSerializer(serializerConfig, JSONSchema.of(Employee.class));
+
+        Employee expected = new Employee(1, "John", "Smith");
+        ByteBuffer serialized = serializer.serialize(expected);
+
+        JsonSerializer jsonSerializer = new JsonSerializer(serializerConfig);
+
+        JsonNode actual = jsonSerializer.deserialize(serialized);
+
+        assertEquals(actual.get("id").asInt(), expected.id);
+        assertEquals(actual.get("first").asText(), expected.first);
+        assertEquals(actual.get("last").asText(), expected.last);
+
+        assertTrue(jsonSerializer.schemaRegistryDeserializer());
+    }
+
+    private SerializerConfig jsonGroup(String stream) {
+        String groupId = "json." + stream;
+        addGroup(groupId, SerializationFormat.Json);
+        return serializerConfig(groupId);
+    }
+
+    private void addGroup(String groupId, SerializationFormat format)
+    {
+        schemaRegistry.client().addGroup(groupId,
+                new GroupProperties(
+                        format,
+                        Compatibility.allowAny(),
+                        true));
+    }
+
+    private SerializerConfig serializerConfig(String group) {
+        return SerializerConfig.builder()
+                .groupId(group).registryConfig(SchemaRegistryClientConfig.builder()
+                        .schemaRegistryUri(schemaRegistry.getURI())
+                        .build())
+                .registerSchema(true)
+                .build();
+    }
+
+    @AfterClass(alwaysRun = true)
+    public void destroy()
+    {
+        schemaRegistry.close();
+    }
+}

--- a/src/test/java/io/pravega/connectors/presto/integration/EmbeddedSchemaRegistry.java
+++ b/src/test/java/io/pravega/connectors/presto/integration/EmbeddedSchemaRegistry.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) Dell Inc., or its subsidiaries. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Note: this class is based on SetupUtils from pravega/flink-connectors
+ * (rev 9332ad67e520c03c7122de1d3b90c6cafbf97634)
+ * https://github.com/pravega/flink-connectors/blob/v0.9.0/src/test/java/io/pravega/connectors/flink/utils/SetupUtils.java
+ */
+package io.pravega.connectors.presto.integration;
+
+import java.io.Closeable;
+import java.net.URI;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import io.pravega.schemaregistry.client.SchemaRegistryClient;
+import io.pravega.schemaregistry.client.SchemaRegistryClientConfig;
+import io.pravega.schemaregistry.client.SchemaRegistryClientFactory;
+import io.pravega.schemaregistry.server.rest.RestServer;
+import io.pravega.schemaregistry.server.rest.ServiceConfig;
+import io.pravega.schemaregistry.service.SchemaRegistryService;
+import io.pravega.schemaregistry.storage.SchemaStore;
+import io.pravega.schemaregistry.storage.SchemaStoreFactory;
+
+public class EmbeddedSchemaRegistry
+        implements Closeable {
+    private final static AtomicInteger servers = new AtomicInteger();
+
+    private final int port;
+
+    private final AtomicBoolean started = new AtomicBoolean();
+
+    private final ScheduledExecutorService executor;
+
+    private RestServer restServer;
+
+    private SchemaRegistryClient client;
+
+    public EmbeddedSchemaRegistry() {
+        port = 9100 + servers.getAndIncrement();
+        executor = Executors.newScheduledThreadPool(10);
+
+        SchemaStore schemaStore = SchemaStoreFactory.createInMemoryStore(executor);
+
+        restServer = new RestServer(
+                new SchemaRegistryService(schemaStore, executor),
+                ServiceConfig.builder().port(port).build()
+        );
+    }
+
+    public void start() {
+        if (started.compareAndSet(false, true)) {
+            restServer.startAsync();
+            restServer.awaitRunning();
+        }
+    }
+
+    public void stop() {
+        if (started.compareAndSet(true, false)) {
+            restServer.stopAsync();
+            restServer.awaitTerminated();
+            executor.shutdownNow();
+        }
+    }
+
+    public int port() {
+        return port;
+    }
+
+    public URI getURI() {
+        return URI.create("http://localhost:" + port);
+    }
+
+    public SchemaRegistryClient client()
+    {
+        if (client == null) {
+            SchemaRegistryClientConfig config = SchemaRegistryClientConfig.builder()
+                    .schemaRegistryUri(getURI())
+                    .build();
+            client = SchemaRegistryClientFactory.withDefaultNamespace(config);
+        }
+        return client;
+    }
+
+    @Override
+    public void close()
+    {
+        try {
+            stop();
+        }
+        catch (Exception quiet) {}
+    }
+}

--- a/src/test/java/io/pravega/connectors/presto/integration/EmbeddedSchemaRegistry.java
+++ b/src/test/java/io/pravega/connectors/presto/integration/EmbeddedSchemaRegistry.java
@@ -9,7 +9,7 @@
  *
  * Note: this class is based on SetupUtils from pravega/flink-connectors
  * (rev 9332ad67e520c03c7122de1d3b90c6cafbf97634)
- * https://github.com/pravega/flink-connectors/blob/v0.9.0/src/test/java/io/pravega/connectors/flink/utils/SetupUtils.java
+ * https://github.com/pravega/flink-connectors/blob/v0.9.0/src/test/java/io/pravega/connectors/flink/utils/SchemaRegistryUtils.java
  */
 package io.pravega.connectors.presto.integration;
 

--- a/src/test/java/io/pravega/connectors/presto/integration/EmbeddedSchemaRegistry.java
+++ b/src/test/java/io/pravega/connectors/presto/integration/EmbeddedSchemaRegistry.java
@@ -7,7 +7,7 @@
  *
  *     http://www.apache.org/licenses/LICENSE-2.0
  *
- * Note: this class is based on SetupUtils from pravega/flink-connectors
+ * Note: this class is based on SchemaRegistryUtils from pravega/flink-connectors
  * (rev 9332ad67e520c03c7122de1d3b90c6cafbf97634)
  * https://github.com/pravega/flink-connectors/blob/v0.9.0/src/test/java/io/pravega/connectors/flink/utils/SchemaRegistryUtils.java
  */

--- a/src/test/java/io/pravega/connectors/presto/integration/PravegaKeyValueLoader.java
+++ b/src/test/java/io/pravega/connectors/presto/integration/PravegaKeyValueLoader.java
@@ -24,15 +24,13 @@ import io.pravega.client.tables.KeyValueTable;
 import io.pravega.client.tables.KeyValueTableClientConfiguration;
 import io.pravega.client.tables.KeyValueTableConfiguration;
 import io.pravega.connectors.presto.util.ByteBufferInputStream;
+import io.pravega.connectors.presto.util.PravegaSerializationUtils;
 import org.apache.avro.Schema;
 import org.apache.avro.file.DataFileStream;
-import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericDatumReader;
-import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.DatumReader;
 
-import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.URI;
@@ -54,19 +52,7 @@ public class PravegaKeyValueLoader
         @Override
         public ByteBuffer serialize(GenericRecord record)
         {
-            try {
-                GenericDatumWriter<GenericRecord> writer = new GenericDatumWriter<>(record.getSchema());
-                DataFileWriter<GenericRecord> dataFileWriter = new DataFileWriter<>(writer);
-
-                ByteArrayOutputStream os = new ByteArrayOutputStream();
-                dataFileWriter.create(record.getSchema(), os);
-                dataFileWriter.append(record);
-                dataFileWriter.close();
-                return ByteBuffer.wrap(os.toByteArray());
-            }
-            catch (IOException e) {
-                throw new UncheckedIOException(e);
-            }
+            return PravegaSerializationUtils.serialize(record);
         }
 
         @Override

--- a/src/test/proto/Product.proto
+++ b/src/test/proto/Product.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+package io.pravega.protobuf;
+
+message Product {
+  int32 id = 1;
+  string name = 2;
+}


### PR DESCRIPTION
Closes #20 

Currently we rely on a client application adding a separate boolean property to pravega SchemaRegistry group properties to determine if the objects written to the stream use SchemaRegistry serializers and thus schema data is managed automatically (and encoding info is inlined in the raw event data) 

This PR removes the need for this out-of-band property to be set, and will auto-detect.
