### PR TITLE
Issue 55: include deps in tarball dist.

### DIFF
--- a/prestodb/build.gradle
+++ b/prestodb/build.gradle
@@ -104,6 +104,7 @@ distributions {
         contents {
             distributionBaseName = 'pravega-presto-connector'
             from jar
+            from(project.configurations.runtime)
         }
     }
 }

--- a/trino/build.gradle
+++ b/trino/build.gradle
@@ -111,6 +111,7 @@ distributions {
         contents {
             distributionBaseName = 'pravega-trino-connector'
             from jar
+            from(project.configurations.runtime)
         }
     }
 }


### PR DESCRIPTION
Closes #55 

./gradlew build now produces following:

```
$ tar -tzf ./prestodb/build/distributions/pravega-presto-connector-0.1.0.tar.gz pravega-presto-connector-0.1.0/ | head
pravega-presto-connector-0.1.0/
pravega-presto-connector-0.1.0/pravega-connector-0.1.0.jar
pravega-presto-connector-0.1.0/presto-main-0.247.jar
pravega-presto-connector-0.1.0/discovery-server-1.33.jar
pravega-presto-connector-0.1.0/bootstrap-0.198.jar
pravega-presto-connector-0.1.0/presto-record-decoder-0.247.jar
pravega-presto-connector-0.1.0/presto-geospatial-toolkit-0.247.jar
pravega-presto-connector-0.1.0/presto-client-0.247.jar
pravega-presto-connector-0.1.0/jmx-http-0.198.jar
pravega-presto-connector-0.1.0/jaxrs-0.198.jar
```

```
$ tar -tzf ./trino/build/distributions/pravega-trino-connector-359.tar.gz | head
pravega-trino-connector-359/
pravega-trino-connector-359/trino-pravega-359.jar
pravega-trino-connector-359/trino-server-dev-359.jar
pravega-trino-connector-359/trino-server-main-359.jar
pravega-trino-connector-359/trino-main-359.jar
pravega-trino-connector-359/trino-client-359.jar
pravega-trino-connector-359/trino-plugin-toolkit-359.jar
pravega-trino-connector-359/trino-record-decoder-359.jar
pravega-trino-connector-359/discovery-server-1.30.jar
pravega-trino-connector-359/bootstrap-207.jar
```

Signed-off-by: Andrew Robertson <andrew.robertson@dell.com>